### PR TITLE
Fix: explain any class in LIME

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,4 @@ Output:
 to the classification in a `target class`. 
 - `exp_neg` - explanation with marked features which contribute 
 against the classification in a `target class`.
+

--- a/keras_explain/lime_ribeiro.py
+++ b/keras_explain/lime_ribeiro.py
@@ -13,7 +13,8 @@ class Lime:
     def explain(self, image, target_class):
         explainer = lime_image.LimeImageExplainer()
         explanation = explainer.explain_instance(
-            image, self.model.predict, top_labels=5, num_samples=1000)
+            image, self.model.predict, top_labels=None,
+            labels=(target_class,), num_samples=1000)
         temp, mask = explanation.get_image_and_mask(
             target_class, positive_only=False, num_features=10, hide_rest=True)
 

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -26,6 +26,7 @@ class TestBasicFunction(unittest.TestCase):
         self.model = InceptionV3(include_top=True, weights='imagenet',
                                  input_shape=(299, 299, 3))
         self.model.compile(optimizer='adam', loss='categorical_crossentropy')
+
         images = [image.load_img(
             os.path.join(path, name), target_size=(299, 299))
             for name in images_names]
@@ -34,6 +35,7 @@ class TestBasicFunction(unittest.TestCase):
         self.images = preprocess_input(images)
 
     def _test_approach(self, approach, kwargs, images):
+        print("Testing", approach)
         explainer = approach(**kwargs)
         for image in images:
             exp_pos, exp_neg = explainer.explain(image, 15)


### PR DESCRIPTION
**Issue**

Only top 5 classes could be explained. https://github.com/PrimozGodec/keras-explain/issues/1

**Description of changes **

Changed that any target class can be explained.